### PR TITLE
rails-shopping-cart-gke to 0.0.6

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -1,9 +1,12 @@
 dependencies:
-- name: exposecontroller
-  version: 2.3.56
+- alias: expose
+  name: exposecontroller
   repository: https://chartmuseum.build.cd.jenkins-x.io
-  alias: expose
-- name: exposecontroller
   version: 2.3.56
+- alias: cleanup
+  name: exposecontroller
   repository: https://chartmuseum.build.cd.jenkins-x.io
-  alias: cleanup
+  version: 2.3.56
+- name: rails-shopping-cart-gke
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.6


### PR DESCRIPTION
Promote rails-shopping-cart-gke to version 0.0.6